### PR TITLE
feat: clean data to movies dataset

### DIFF
--- a/src/ace_of_splades/data.py
+++ b/src/ace_of_splades/data.py
@@ -26,4 +26,20 @@ def get_movies_dataset(sample: int = 0, *, local: bool = False) -> pl.DataFrame:
     if sample:
         return pl.read_parquet(source).sample(sample)
 
-    return pl.read_parquet(source)
+    movies = pl.read_parquet(source).rename(
+        {
+            "Release Year": "release_year",
+            "Title": "title",
+            "Origin/Ethnicity": "origin",
+            "Director": "director",
+            "Cast": "cast",
+            "Genre": "genre",
+            "Wiki Page": "wiki_page",
+            "Plot": "plot",
+        },
+    )
+
+    return movies.with_columns(
+        pl.col("cast").str.split(by=",").alias("cast"),
+        pl.col("genre").str.split(by="/").alias("genre"),
+    )


### PR DESCRIPTION
This pull request includes changing the `get_movies_dataset` function in the `src/ace_of_splades/data.py` file. The change involves renaming columns and splitting specific columns for better data processing.

Improvements to data processing:

* [`src/ace_of_splades/data.py`](diffhunk://#diff-814613f36161eb405d53b8118ac3779c90b0a33bba274065e79d21f4b0468ec3L29-R45): Renamed columns for consistency and readability (`Release Year` to `release_year`, `Title` to `title`, `Origin/Ethnicity` to `origin`, `Director` to `director`, `Cast` to `cast`, `Genre` to `genre`, `Wiki Page` to `wiki_page`, `Plot` to `plot`).
* [`src/ace_of_splades/data.py`](diffhunk://#diff-814613f36161eb405d53b8118ac3779c90b0a33bba274065e79d21f4b0468ec3L29-R45): Split the `cast` column by commas and the `genre` column by slashes to create lists of cast members and genres.