### PR TITLE
feat: add metadata search to improve RAG

### DIFF
--- a/notebooks/03-improve-metadata-search.ipynb
+++ b/notebooks/03-improve-metadata-search.ipynb
@@ -1,0 +1,499 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Improve Metadata Search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: add more descriptions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "Our RAG is not very good on answering questions regarding movies metadata such as release year or gnre o. \n",
+    "For example, how our system deal with questions like: \n",
+    "- Could you suggest a romantic movies from '90s\n",
+    "- I love action movies could you suggest one? \n",
+    "\n",
+    "Right now, with just the simple semantic search between query and movies plots we don't leverage the metadata stored in our database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "\n",
+    "if not importlib.util.find_spec(\"ace\"):\n",
+    "    !pip install -qqq git+https://github.com/xtreamsrl/ace-of-splades"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## Let's Play with LanceDB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ace_of_splades.data import get_movies_dataset\n",
+    "from sentence_transformers import SentenceTransformer\n",
+    "from ace_of_splades.data import get_movies_dataset\n",
+    "import lancedb\n",
+    "import openai\n",
+    "import polars as pl\n",
+    "from pydantic import BaseModel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_path = f\"../data\"\n",
+    "encoder = SentenceTransformer(\"all-MiniLM-L6-v2\")\n",
+    "movies = get_movies_dataset(local=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uri = f\"{data_path}/movies_embeddings\"\n",
+    "db = lancedb.connect(uri)\n",
+    "\n",
+    "movies_table = db.create_table(\"movies\", movies, mode=\"overwrite\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "Let's see what movies are retrieved from database just using semantic search."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "question = \"I love '90 fantasy movies with dragons\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "movies_table.search(\n",
+    "    encoder.encode(question)\n",
+    ").limit(10).select(\n",
+    "    ['title', 'release_year', 'genre']\n",
+    ").to_list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "The retrieved movies looks good, they are all aventure or fantasy movies with some relation with dragosn as asked by the user. **The problem is that many of them are not from 90s!** This is due the fact that the semantic search using enbeddings doesn't taken into account the movies release year.\n",
+    "\n",
+    "Fortunatelly, many vector database have a useful filtering query system. LanceDB, for example, support filtering data using a SQL-like language."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "movies_table.search(\n",
+    "    encoder.encode(question)\n",
+    ").where(\n",
+    "    \"genre LIKE '%fantasy%' AND (release_year >= 1990 AND release_year < 2000)\"\n",
+    ").select(['title', 'release_year', 'genre']).limit(5).to_list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "Hurray! Looks better, all movies now are from 90s. Now the metadata informations in the questions are useless we could just search for \"dragons\" and see what happen!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "movies_table.search(\n",
+    "    encoder.encode(\"dragons\")\n",
+    ").where(\n",
+    "    \"genre LIKE '%fantasy%' AND (release_year >= 1990 AND release_year < 2000)\"\n",
+    ").select(['title', 'release_year', 'genre']).limit(5).to_list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "Even better! So, based on this experiments we need something to convert the natural language user query to a SQL-like filter (or other languages supported by your vector database). \n",
+    "\n",
+    "To do this LLM could help us. We can ask a model to do this job for us and adding a step to our RAG."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "QUERY_METADATA_SYS_MESSAGE = \"\"\"Your goal is to structure the user's query to match the request schema provided below.\n",
+    "When responding, use a data structure with the following schema:\n",
+    "\n",
+    "query (string): text string to compare to document contents\n",
+    "filter: (string): logical condition statement for filtering documents\n",
+    "\n",
+    "You need to build filters for a database with the following fields: \n",
+    "\n",
+    "{fields}\n",
+    "\n",
+    "The query string should contain only text expected to match the contents of documents. Any conditions in the filter should not be mentioned in the query.\n",
+    "You can use standard SQL expressions as predicates for filtering operations. You can use the following list of SQL expressions:\n",
+    "\n",
+    "{supported_operations}\n",
+    "\n",
+    "For genre, director, cast, origin use always LIKE with % wildcard at the beggin. For example origin LIKE '%British%'\n",
+    "\n",
+    "Make sure you only use the comparators and logical operators listed above and not others.\n",
+    "Make sure that filters only refer to attributes in the data source.\n",
+    "Make sure that filters only use the attributed names with their function names if there are functions applied to them.\n",
+    "Make sure that filters only use the format `YYYY` when handling years.\n",
+    "Make sure that filters take into account the descriptions of attributes and only make comparisons that are feasible given the type of data being stored.\n",
+    "Make sure that filters are only used as needed. If no filters should be applied, return \"NO_FILTER\" for the filter value.\n",
+    "\n",
+    "<< Example 1. >>\n",
+    "User Query:\n",
+    "I love action American movies with superheroes\n",
+    "\n",
+    "Structured Request:\n",
+    "\"query\": \"Superheroes\",\n",
+    "\"filter\": \"genre LIKE '%action%' AND origin = 'American'\"\n",
+    "\n",
+    "<< Example 2. >>\n",
+    "User Query:\n",
+    "I love '90 fantasy movies with dragons\n",
+    "\n",
+    "Structured Request:\n",
+    "\"query\": \"Dragons\",\n",
+    "\"filter\": \"genre LIKE '%fantasy%' AND (release_year >= 1990 AND release_year < 2000)\"\n",
+    "\"\"\"\n",
+    "\n",
+    "supported_operations = [\n",
+    "    \">, >=, <, <=, =\", \n",
+    "    \"AND, OR, NOT\",\n",
+    "    \"IS NULL, IS NOT NULL\",\n",
+    "    \"IS TRUE, IS NOT TRUE, IS FALSE, IS NOT FALSE\",\n",
+    "    \"IN\",\n",
+    "    \"LIKE, NOT LIKE\",\n",
+    "    \"CAST\",\n",
+    "    \"regexp_match(column, pattern)\"\n",
+    "]\n",
+    "\n",
+    "\n",
+    "formatted_supported_operations = '\\n'.join(supported_operations)\n",
+    "query_metadata_system_message = QUERY_METADATA_SYS_MESSAGE.format(fields =movies_table.schema, supported_operations = formatted_supported_operations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(query_metadata_system_message)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class VectorDBQuery(BaseModel):\n",
+    "    query: str\n",
+    "    filter: str"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def vectordb_query_builder(user_question: str, system_message: str = query_metadata_system_message):\n",
+    "    client = openai.OpenAI()\n",
+    "    prompt = f\"Could you generate query and filter for the following user natural language question: {user_question}\"\n",
+    "    \n",
+    "    chat_completion = client.beta.chat.completions.parse(\n",
+    "        model=\"gpt-4o-mini\",\n",
+    "        messages=[\n",
+    "            {\"role\": \"system\", \"content\": system_message},\n",
+    "            {\"role\": \"user\", \"content\": prompt},\n",
+    "        ],\n",
+    "        response_format=VectorDBQuery\n",
+    "    )\n",
+    "    \n",
+    "    return chat_completion.choices[0].message.parsed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_records(\n",
+    "        query: VectorDBQuery, *, encoder=encoder, db_table=movies_table, max_results=10, verbose = False\n",
+    "):\n",
+    "    query_vector = encoder.encode(query.query).tolist()\n",
+    "    columns = ['release_year', 'title', 'origin', 'director', 'cast', 'genre', 'plot', '_distance']\n",
+    "\n",
+    "    if verbose: \n",
+    "        print(f\"Query: {query.query}\")\n",
+    "        print(f\"Filter: {query.filter}\")\n",
+    "    \n",
+    "    if query.filter == 'NO_FILTER':\n",
+    "        return db_table.search(\n",
+    "            query_vector\n",
+    "        ).limit(max_results).select(\n",
+    "            columns\n",
+    "        ).to_list()\n",
+    "    else: \n",
+    "        return db_table.search(\n",
+    "            query_vector\n",
+    "        ).where(query.filter).limit(max_results).select(\n",
+    "            columns\n",
+    "        ).to_list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21",
+   "metadata": {},
+   "source": [
+    "Now that we have improve the `get_records` methods taking into consideration also metadata. We could build the rag again! "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SYSTEM_MESSAGE = \"\"\" You are a movie expert whose goal is to recommend a good movie to the user.\n",
+    "\n",
+    "RULES: \n",
+    "- You should reply to questions about movie plots or Synopsys, movies metadata (release date, cast, or director), and provide plot summary;\n",
+    "- For every question outside the scope, please reply politely that you're not able to provide a response and describe briefly your scope;\n",
+    "- Don't mention that you have a list of films as a context. This should be transparent to the user\n",
+    "- If you don't have the movie in your context, reply that you don't know how to reply\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt_template = \"\"\"\n",
+    "  Here are some suggested movies (ranked by relevance) to help you with your choice.\n",
+    "  {context}\n",
+    "\n",
+    "  Use these suggestions to answer this question:\n",
+    "  {question}\n",
+    "\"\"\"\n",
+    "\n",
+    "context_template = \"\"\"\n",
+    "Title: {title}\n",
+    "Release date: {release_year}\n",
+    "Director: {director}\n",
+    "Cast: {cast}\n",
+    "Genre: {genre}\n",
+    "Overview: {plot}\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
+    "def format_records_into_context(records, *, template):\n",
+    "    return \"\".join(\n",
+    "        context_template.format(\n",
+    "            title=rec[\"title\"],\n",
+    "            release_year=rec[\"release_year\"],\n",
+    "            director=rec[\"director\"],\n",
+    "            cast=rec[\"cast\"],\n",
+    "            genre=rec[\"genre\"],\n",
+    "            plot=rec[\"plot\"],\n",
+    "        )\n",
+    "        for rec in records\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = openai.OpenAI()\n",
+    "\n",
+    "\n",
+    "def ask(\n",
+    "        question,\n",
+    "        *,\n",
+    "        max_results=10,\n",
+    "        system=SYSTEM_MESSAGE,\n",
+    "        prompt_template=prompt_template,\n",
+    "        context_template=context_template,\n",
+    "        db_table=movies_table,\n",
+    "        verbose=False\n",
+    "):\n",
+    "    db_query = vectordb_query_builder(question)\n",
+    "    records = get_records(\n",
+    "        query=db_query, max_results=max_results, db_table=movies_table, verbose = verbose\n",
+    "    )\n",
+    "\n",
+    "    context = format_records_into_context(records, template=context_template)\n",
+    "\n",
+    "    prompt = prompt_template.format(question=question, context=context)\n",
+    "\n",
+    "    chat_completion = client.chat.completions.create(\n",
+    "        model=\"gpt-4o-mini\",\n",
+    "        messages=[\n",
+    "            {\"role\": \"system\", \"content\": system},\n",
+    "            {\"role\": \"user\", \"content\": prompt},\n",
+    "        ],\n",
+    "    )\n",
+    "\n",
+    "    answer = chat_completion\n",
+    "    if verbose:\n",
+    "        print(answer.choices[0].message.content)\n",
+    "\n",
+    "    return answer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25",
+   "metadata": {},
+   "source": [
+    "# Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "question = \"I love '90 fantasy movies with dragons\"\n",
+    "answer = ask(question=question, verbose=True)\n",
+    "print()\n",
+    "print(answer.choices[0].message.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "question = \"How many Rocky movies where filmed?\"\n",
+    "answer = ask(question=question, verbose=True) \n",
+    "print()\n",
+    "print(answer.choices[0].message.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "question = \"I love Turkish movies, and my prefered director is Özpetek! What movie I can see?\"\n",
+    "answer = ask(question=question, verbose=True) \n",
+    "print(answer.choices[0].message.content)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/ace_of_splades/data.py
+++ b/src/ace_of_splades/data.py
@@ -26,7 +26,7 @@ def get_movies_dataset(sample: int = 0, *, local: bool = False) -> pl.DataFrame:
     if sample:
         return pl.read_parquet(source).sample(sample)
 
-    movies = pl.read_parquet(source).rename(
+    return pl.read_parquet(source).rename(
         {
             "Release Year": "release_year",
             "Title": "title",
@@ -37,9 +37,4 @@ def get_movies_dataset(sample: int = 0, *, local: bool = False) -> pl.DataFrame:
             "Wiki Page": "wiki_page",
             "Plot": "plot",
         },
-    )
-
-    return movies.with_columns(
-        pl.col("cast").str.split(by=",").alias("cast"),
-        pl.col("genre").str.split(by="/").alias("genre"),
     )


### PR DESCRIPTION
This pull request includes changes to the `get_movies_dataset` function in the `src/ace_of_splades/data.py` file to streamline the code and improve its readability. And add the notebook `notebooks/03-improve-metadata-search.ipynb` containing the code to teach audience about how to implement a metadata search.

Code simplification:
* [`src/ace_of_splades/data.py`](diffhunk://#diff-814613f36161eb405d53b8118ac3779c90b0a33bba274065e79d21f4b0468ec3L29-R29): Removed the intermediate `movies` variable and directly returned the result of the `pl.read_parquet` call with column renaming.
* [`src/ace_of_splades/data.py`](diffhunk://#diff-814613f36161eb405d53b8118ac3779c90b0a33bba274065e79d21f4b0468ec3L41-L45): Removed the redundant `with_columns` call that split the `cast` and `genre` columns, as this functionality is no longer required.