### PR TITLE
feat: add judge run to rag improvements notebooks

### DIFF
--- a/notebooks/03-improve-metadata-search.ipynb
+++ b/notebooks/03-improve-metadata-search.ipynb
@@ -60,6 +60,8 @@
    "outputs": [],
    "source": [
     "from ace_of_splades.data import get_movies_dataset\n",
+    "from ace_of_splades.judge import llm_as_a_judge, answer_multiple_questions\n",
+    "\n",
     "from sentence_transformers import SentenceTransformer\n",
     "from ace_of_splades.data import get_movies_dataset\n",
     "import lancedb\n",
@@ -472,6 +474,65 @@
     "question = \"I love Turkish movies, and my preferred director is Özpetek! What movie can I see?\"\n",
     "answer = ask(question=question, verbose=True) \n",
     "print(answer.choices[0].message.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29",
+   "metadata": {},
+   "source": [
+    "# But... Is Our RAG Improved?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30",
+   "metadata": {},
+   "source": [
+    "Let's take our questions/answers dataset and run again our LLM-as-a-Judge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "questions_answers_df = pl.read_excel(\n",
+    "    source=\"../data/eval_questions_with_critiques.xlsx\",\n",
+    "    sheet_name=\"Sheet1\",\n",
+    ").select([\"question\", \"rag_answer\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "replied_answers = answer_multiple_questions(questions_answers_df, ask)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "judged_questions_answer_df = llm_as_a_judge(questions_answers_df, client)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "judged_questions_answer_df"
    ]
   }
  ],

--- a/notebooks/04-HyDE.ipynb
+++ b/notebooks/04-HyDE.ipynb
@@ -40,8 +40,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import openai\n",
     "from ace_of_splades.data import get_movies_dataset\n",
+    "from ace_of_splades.judge import llm_as_a_judge, answer_multiple_questions\n",
+    "\n",
+    "import openai\n",
+    "import polars as pl\n",
     "from sentence_transformers import SentenceTransformer\n",
     "import lancedb"
    ]
@@ -257,6 +260,65 @@
     "\n",
     "\n",
     "answer = ask(question=question, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "# But... Is Our RAG Improved?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "Let's take our questions/answers dataset and run again our LLM-as-a-Judge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "questions_answers_df = pl.read_excel(\n",
+    "    source=\"../data/eval_questions_with_critiques.xlsx\",\n",
+    "    sheet_name=\"Sheet1\",\n",
+    ").select([\"question\", \"rag_answer\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "replied_answers = answer_multiple_questions(questions_answers_df, ask)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "judged_questions_answer_df = llm_as_a_judge(questions_answers_df, client)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "judged_questions_answer_df"
    ]
   }
  ],

--- a/src/ace_of_splades/judge.py
+++ b/src/ace_of_splades/judge.py
@@ -1,0 +1,168 @@
+"""Collections of utils for LLM as a Judge."""
+
+from collections.abc import Callable
+
+import polars as pl
+from openai import OpenAI
+from pydantic import BaseModel
+
+
+class EvaluationExample(BaseModel):
+    """Contains an example for LLM as a judge."""
+
+    question: str
+    response: str
+    outcome: str
+    critique: str
+
+
+class LLMJudgeDataset(BaseModel):
+    """Contains the format for LLM as a Judge output."""
+
+    critiques: list[EvaluationExample]
+
+
+JUDGE_SYSTEM_MESSAGE = """You are a movie expert chatbot evaluator with
+advanced capabilities to understand if the question response is good or not.
+Follow some guidelines to evaluate the system:
+{guidelines}
+
+We provide you with some examples to give you an idea of how a good response should be.
+Evaluation examples:
+{examples}
+"""
+
+
+EXAMPLE_STRUCTURE = """<user_question>{question}</user_question>
+<response>{response}</response>
+<outcome>{outcome}</outcome>
+<critique>{critique}</critique>"""
+
+
+evaluation_guidelines = [
+    'Provide a "pass" or "fail" outcome. No other category is admitted.',
+    "Provide a comprehensive and clear explanation of "
+    'why you gave that outcome. In particular for the "fail" one',
+]
+
+
+examples = [
+    EvaluationExample(
+        question="Could you suggest an action movie?",
+        response='I recommend "The Thousand Faces of Dunjia" (2017), '
+        "directed by Yuen Woo-ping. "
+        "The film follows a group of swordsmen's adventures as they secretly "
+        "protect humanity by hunting "
+        "down mysterious creatures from outer space. It combines action "
+        "and fantasy elements, "
+        "making it an engaging watch for fans of the genre. Enjoy!",
+        outcome="pass",
+        critique="The system replied with an action movie correctly. "
+        "The response is brief but well explained.",
+    ),
+    EvaluationExample(
+        question="Give me a summary of DUNE II",
+        response="I'm sorry, but I don't have information about \"Dune II.\" "
+        "My expertise covers movie plots, metadata, and summaries of films, "
+        "but it seems that title isn't available in my current context. "
+        "If you have any questions about other movies, feel free to ask!",
+        outcome="fail",
+        critique="The system should reply to questions regarding movie summaries. "
+        "It seems that can't find the movie in the context.",
+    ),
+]
+
+
+def llm_as_a_judge(
+    questions: pl.DataFrame,
+    client: OpenAI,
+) -> pl.DataFrame:
+    """Evaluate a list of questions using the LLM as a judge.
+
+    Args:
+        questions: A dataset of questions.
+        client: An OpenAI client.
+
+    Returns:
+        A dataset with the questions, the answers, and the critiques.
+
+    """
+    formatted_system_message = _build_evaluation_system_message(
+        JUDGE_SYSTEM_MESSAGE,
+        evaluation_guidelines,
+        examples,
+    )
+
+    formatted_questions = (
+        questions.select(
+            pl.format(
+                "Question: {}\nAnswer: {}\n\n",
+                pl.col("question"),
+                pl.col("rag_answer"),
+            ),
+        )
+        .to_series(0)
+        .str.join("\n")
+        .item()
+    )
+
+    prompt = f"""Evaluate how our AI system answered the given questions.
+    Here is the list of question and answer couples: {formatted_questions}"""
+
+    chat_completion = client.beta.chat.completions.parse(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": formatted_system_message},
+            {"role": "user", "content": prompt},
+        ],
+        response_format=LLMJudgeDataset,
+    )
+
+    llm_judge_outcome = chat_completion.choices[0].message.parsed
+
+    return pl.from_dicts(llm_judge_outcome.model_dump()["critiques"])
+
+
+def answer_multiple_questions(questions: pl.DataFrame, ask: Callable) -> pl.DataFrame:
+    """Utility function to answer multiple questions using the ask function.
+
+    Args:
+        questions: A dataset of questions.
+        ask: A function that receives a question and returns an answer.
+
+    Returns:
+        A dataset with the questions and the ask answers.
+
+    """
+    return questions.with_columns(
+        pl.col("question")
+        .map_elements(
+            lambda question: ask(question).choices[0].message.content,
+            return_dtype=pl.String,
+        )
+        .alias("rag_answer"),
+    )
+
+
+def _build_evaluation_examples(example: EvaluationExample) -> str:
+    return EXAMPLE_STRUCTURE.format(
+        question=example.question,
+        response=example.response,
+        outcome=example.outcome,
+        critique=example.critique,
+    )
+
+
+def _build_evaluation_system_message(
+    system_message: str,
+    guidelines: str,
+    examples: list[EvaluationExample],
+) -> str:
+    formatted_guidelines = "\n".join(guidelines)
+    formatted_examples = "\n\n".join(
+        [_build_evaluation_examples(ex) for ex in examples],
+    )
+    return system_message.format(
+        guidelines=formatted_guidelines,
+        examples=formatted_examples,
+    )


### PR DESCRIPTION
This pull request includes significant updates to the notebooks and the addition of a new utility module for evaluating question-answer pairs using a language model. The key changes are summarized below:

### Enhancements to Notebooks:

* [`notebooks/03-improve-metadata-search.ipynb`](diffhunk://#diff-61708a6cff9ed04731c2cf98fa2473780ab4abdf2cc15adf5ad6b2935d99ccfaR63-R64): Added imports for `llm_as_a_judge` and `answer_multiple_questions`, and included new cells to evaluate the RAG (Retrieval-Augmented Generation) model using these functions. [[1]](diffhunk://#diff-61708a6cff9ed04731c2cf98fa2473780ab4abdf2cc15adf5ad6b2935d99ccfaR63-R64) [[2]](diffhunk://#diff-61708a6cff9ed04731c2cf98fa2473780ab4abdf2cc15adf5ad6b2935d99ccfaR478-R536)
* [`notebooks/04-HyDE.ipynb`](diffhunk://#diff-31db46976a8aa516b8f8d0345b2c60547a5ea35e61de7abc04eba050d20fdd34L43-R47): Reordered imports and added new cells to evaluate the RAG model using the `llm_as_a_judge` and `answer_multiple_questions` functions. [[1]](diffhunk://#diff-31db46976a8aa516b8f8d0345b2c60547a5ea35e61de7abc04eba050d20fdd34L43-R47) [[2]](diffhunk://#diff-31db46976a8aa516b8f8d0345b2c60547a5ea35e61de7abc04eba050d20fdd34R264-R322)

### New Utility Module:

* [`src/ace_of_splades/judge.py`](diffhunk://#diff-9aa498b8f51e51d362708c553c9cfde28a28623c3e1e6364782e13546e634d78R1-R168): Introduced a new module with utility functions for evaluating question-answer pairs using a language model. This includes the `llm_as_a_judge` function to evaluate responses, and `answer_multiple_questions` to generate answers for multiple questions. The module also defines data structures for evaluation examples and guidelines.