### PR TITLE
docs: add documentation text to 01 nb

### DIFF
--- a/notebooks/01-first-rag.ipynb
+++ b/notebooks/01-first-rag.ipynb
@@ -1,26 +1,21 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "0",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "import importlib\n",
-    "\n",
-    "if not importlib.util.find_spec(\"ace\"):\n",
-    "    !pip install -qqq git+https://github.com/xtreamsrl/ace-of-splades"
+    "# Our Product: A Movie Expert"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "1",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "data_path = \"../data\""
+    "After a couple of months of work, we finally finished our product. At voilà: a robotic movie expert ready to go on production and reply to all cinema geeks' questions! \n",
+    "\n",
+    "Let's have a look at the code."
    ]
   },
   {
@@ -30,13 +25,44 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "os.environ[\"OPENAI_API_KEY\"] = ..."
+    "import importlib\n",
+    "\n",
+    "if not importlib.util.find_spec(\"ace\"):\n",
+    "    !pip install -qqq git+https://github.com/xtreamsrl/beyond-the-hype"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_path = \"../data\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ[\"OPENAI_API_KEY\"] = ..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "We need a dataset of movies to give context to an LLM. We get our movies dataset with a util function from our package. You can find more information about data in the [Embed Movies into Vectors](./notebooks/00-datasets_builder.ipynb) [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/xtreamsrl/movies-buddy/blob/main/notebooks/00-dataset_builder.ipynb) notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,9 +82,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "We need a sentence transoformer to encode the user query. Note that, it must the same one used to embed the dataset vectors "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,32 +102,32 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "Let's now build records getter. We leverage the power of lanceDB, an in-memory vector storage, to store our movies and vectors and build a function to retrieve movies given a user query"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
     "import lancedb\n",
     "\n",
     "uri = f\"{data_path}/movies_embeddings\"\n",
-    "db = lancedb.connect(uri)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "db = lancedb.connect(uri)\n",
+    "\n",
     "movies_table = db.create_table(\"movies\", movies, mode=\"overwrite\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,9 +160,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "Now, the RAG! In the following cells we construct the system message and the prompt of our movie expert. Of course, the prompt must include the movies retrieved by the vector store as context for the LLM."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,9 +222,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "Everything ready to ask a LLM to reply the user questions! "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,12 +274,30 @@
     "    return answer\n",
     "\n",
     "\n",
-    "answer = ask(question=question, verbose=True)"
+    "answer = ask(question=question, verbose=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(answer.choices[0].message.content)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "**Is this reply good?** Well, it looks good. It replies in a funny tone and suggests a movie! Maybe it's too long... or too short? "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20",
    "metadata": {},
    "source": [
     "# Let's Run Our First Evaluation Questions"
@@ -238,7 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,16 +315,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "22",
    "metadata": {},
    "source": [
-    "Now that we have generated some questions to boostrap our evaluation process we must make our system reply"
+    "Now that we have generated some questions to bootstrap our evaluation process, we must make our system reply. "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +345,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ace_of_splades.judge import answer_multiple_questions\n",
+    "\n",
+    "replied_questions = answer_multiple_questions(eval_dataset, ask)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,12 +383,12 @@
     "pl.Config.set_fmt_str_lengths(PL_STR_LEN)\n",
     "pl.Config.set_tbl_width_chars(PL_STR_LEN)\n",
     "\n",
-    "eval_dataset"
+    "replied_questions"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "28",
    "metadata": {},
    "source": [
     "Cool! Our movie expert replies to all the questions in our dataset; our work here is done! But... let's see what our **movie expert** would say about it.\n",
@@ -319,7 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +411,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "30",
    "metadata": {},
    "source": [
     "Let's see what the domain expert voted"
@@ -340,7 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,7 +445,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "33",
    "metadata": {},
    "source": [
     "There are a lot of failures (80%), so let's eye-balling the critiques from the domain expert and cluster them in groups. Possible groups could be:\n",
@@ -376,7 +456,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "34",
    "metadata": {},
    "source": [
     "## The \"Easiest First\" Rule\n",
@@ -388,7 +468,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +478,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -407,7 +487,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "37",
    "metadata": {},
    "source": [
     "Let's quickly iterate through our system message to check if we could have a better response."
@@ -416,7 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -432,7 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -451,7 +531,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -475,7 +555,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pull request includes significant updates to the `notebooks/01-first-rag.ipynb` file, primarily adding markdown cells to improve the documentation and explanation of the notebook's content. Additionally, it includes some minor code adjustments and updates.

Documentation improvements:

* Added several markdown cells to provide context and explanations for the code, including an introduction to the product, dataset information, and step-by-step descriptions of the process. [[1]](diffhunk://#diff-106d6f16cab30e5bcc215fec3375ecced271b83455c4c9539ef204cde9eb8447R3-R37) [[2]](diffhunk://#diff-106d6f16cab30e5bcc215fec3375ecced271b83455c4c9539ef204cde9eb8447L29-R65) [[3]](diffhunk://#diff-106d6f16cab30e5bcc215fec3375ecced271b83455c4c9539ef204cde9eb8447L51-R95) [[4]](diffhunk://#diff-106d6f16cab30e5bcc215fec3375ecced271b83455c4c9539ef204cde9eb8447R162-R173) [[5]](diffhunk://#diff-106d6f16cab30e5bcc215fec3375ecced271b83455c4c9539ef204cde9eb8447R224-R235)

Code adjustments:

* Changed the installation command to use a different repository: `ace-of-splades` to `beyond-the-hype`.
* Modified the `ask` function call to set `verbose` to `False` instead of `True`.
* Updated the Python version metadata from `3.12.8` to `3.12.3`.