### PR TITLE
docs: add documentation text to 02 nb

### DIFF
--- a/notebooks/02-domain-expert.ipynb
+++ b/notebooks/02-domain-expert.ipynb
@@ -5,17 +5,19 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "## You Need A Domain Expert"
+    "## You Need A Subject Matter Expert!"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "1",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# TODO: add explaination about domain expert"
+    "We need to evaluate our AI product. I saw you googling (or chatGPTing) for the best metric to assess your RAG. *Stop it immediately!* A typical error when building an evaluation system for an RAG is adopting many confusing metrics. **It is hard to find a quality response metric in a domain with open-ended responses, especially at the beginning.**\n",
+    "\n",
+    "Before digging into fancy metrics, **you must involve Subject Matters Experts (SMEs)** in the project to build a successful AI product. Someone who knows everything about the domain and will use your product or is interested in creating a helpful product: If you are building an AI system that needs to reply to new employee questions about the onboarding process, you can involve an HR manager. Again, involve a layer if your product must respond to juridic questions. \n",
+    "\n",
+    "You should get the idea: we are building a movie expert, so we need a cinema geek! "
    ]
   },
   {
@@ -27,9 +29,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "Now that we have chosen our SME, what could we ask him/her? We could ask him to judge some answers our system gives to a list of questions. We can leverage the power of LLM to invent questions for use, this could be useful to bootstrap our evaluation pipeline. "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,9 +71,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "To instruct the LLM to generate valuable questions to use as an evaluation dataset we could think about different characteristics that our product must have, in particular: \n",
+    "- Which **features** should our system have? What it must do specifically?\n",
+    "- Which **scenario** should it be able to address without problems?\n",
+    "- Which kind of **users**  will use the product? Expert users? Technical or non-technical people?\n",
+    "\n",
+    "Let's do this exercise! In the following list, we suggested some possible features, scenarios and personas that our movie expert chatbot should have. Think about the product we are building and try to add yours instead of the dots."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,14 +120,14 @@
     "- You must generate the questions impersonating ONLY the following personas: {personas}\n",
     "\"\"\"\n",
     "\n",
-    "n_rows = 10\n",
-    "EVAL_CONSTRUCTION_PROMPT = \"\"\"Generate an evaluation dataset of {n_rows} rows\"\"\""
+    "MAX_ROWS = 20\n",
+    "EVAL_CONSTRUCTION_PROMPT = \"\"\"Generate an evaluation dataset with no more than {n_rows} rows\"\"\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +195,7 @@
     "    model=\"gpt-4o\",\n",
     "    messages=[\n",
     "        {\"role\": \"system\", \"content\": system_message},\n",
-    "        {\"role\": \"user\", \"content\": EVAL_CONSTRUCTION_PROMPT.format(n_rows=n_rows)},\n",
+    "        {\"role\": \"user\", \"content\": EVAL_CONSTRUCTION_PROMPT.format(n_rows=MAX_ROWS)},\n",
     "    ],\n",
     "    response_format=EvalDataset,\n",
     ")\n",
@@ -185,7 +208,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "answer.model_dump()[\"questions\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "Now, we have a list of questions to pose to our AI and ask our evaluation expert to evaluate it. Note that, the SME could be involved also both for giving you features, scenario and personas or to add particular questions to the generated dataset. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
This pull request includes significant updates to the `notebooks/02-domain-expert.ipynb` file to enhance the content and improve clarity. The changes involve rephrasing titles, adding detailed explanations, and restructuring the notebook cells. 

Content and clarity improvements:

* Changed the title from "Domain Expert" to "Subject Matter Expert" and added a detailed explanation about the importance of involving SMEs in AI projects.
* Added a new markdown cell explaining the next steps after choosing an SME, including leveraging LLM to generate questions for evaluation.
* Included a new section with guidance on instructing the LLM to generate valuable questions, focusing on features, scenarios, and user personas.
* Updated the prompt construction code to use a maximum of 20 rows instead of a fixed 10 rows.
* Added a markdown cell summarizing the process of using the generated questions for SME evaluation.