### PR TITLE
fix: add openai key to nb4

### DIFF
--- a/notebooks/04-HyDE.ipynb
+++ b/notebooks/04-HyDE.ipynb
@@ -40,6 +40,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os \n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from beyond_the_hype.data import get_movies_dataset\n",
     "from beyond_the_hype.judge import llm_as_a_judge, answer_multiple_questions\n",
     "\n",
@@ -52,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "HyDE is composed of two main steps:\n",
@@ -99,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,7 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +288,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "# But... Is Our RAG Improved?"
@@ -284,7 +296,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "Let's take our questions/answers dataset and run again our LLM-as-a-Judge"
@@ -293,7 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
This pull request includes updates to the `notebooks/04-HyDE.ipynb` file, adding a new code cell and updating the IDs of existing cells to maintain the correct sequence.

Key changes:

* Added a new code cell to import the `os` module and set the `OPENAI_API_KEY` environment variable.
* Updated the IDs of existing code cells to maintain the correct sequence:
  * Changed ID from `4` to `5`.
  * Changed ID from `5` to `6`.
  * Changed ID from `6` to `7`.
  * Changed ID from `7` to `8`.
  * Changed ID from `8` to `9`.
  * Changed ID from `9` to `10`.
  * Changed ID from `10` to `11`.
  * Changed ID from `11` to `12`.
  * Changed ID from `12` to `13`.
  * Changed ID from `13` to `14`.
  * Changed ID from `14` to `15`.
  * Changed ID from `15` to `16`.
  * Changed ID from `16` to `17`.
  * Changed ID from `17` to `18`.
  * Changed ID from `18` to `19`.
  * Changed ID from `19` to `20`.
  * Changed ID from `20` to `21`.