### PR TITLE
docs: add more documentation for nb3 and a new final exercise

### DIFF
--- a/notebooks/03-llm-as-a-judge.ipynb
+++ b/notebooks/03-llm-as-a-judge.ipynb
@@ -167,9 +167,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "domain_expert_critiques = pl.read_excel(\n",
-    "    source=\"../data/eval_questions_with_critiques.xlsx\",\n",
-    "    sheet_name=\"Sheet1\",\n",
+    "domain_expert_critiques = pl.read_csv(\n",
+    "    source=\"eval_comments.csv\",\n",
     ")"
    ]
   },
@@ -234,6 +233,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import openai\n",
     "\n",
     "client = openai.OpenAI()\n",
@@ -253,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,16 +277,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
-    "Now, we can compare the judgement of the domain expert with the judgement from the llm-as-a-judge and, if needed, iterate on the tool to align it to the human one."
+    "## How Our Evaluator Perform Compared to Domain Expert?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20",
+   "metadata": {},
+   "source": [
+    "Domain Expert outcomes and critiques are still essential! To determine the performance of the LLM-as-a-judge tool we build, we should compare their response with the one from our domain expert. **Domain expert responses are our ground truth.** The ideal result that we could expect is that the automatic evaluator aligns with human feedback."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,13 +308,29 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "20",
+   "cell_type": "raw",
+   "id": "22",
    "metadata": {},
-   "outputs": [],
    "source": [
     "full_judges"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23",
+   "metadata": {},
+   "source": [
+    "## 🏋🏻 Exercise: Iterate Until LLM-as-a-Judge Align with Domain Expert"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24",
+   "metadata": {},
+   "source": [
+    "Go back to the prompt and system message, try to edit it, and rerun the code until it aligns with the results of the domain expert! \n",
+    "\n",
+    "You could also involve the domain expert again (who should be beside you) to check if the LLM-as-a-judge answer stimulated his change of mind. The results might surprise you!"
    ]
   }
  ],
@@ -315,7 +350,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pull request includes several updates to the `notebooks/03-llm-as-a-judge.ipynb` file to improve data handling, add necessary imports, and enhance the clarity of markdown explanations. The most important changes include switching from reading an Excel file to a CSV file, adding environment variable setup for the OpenAI API key, and updating markdown cells for better clarity.

Data handling improvements:
* Changed the data source from reading an Excel file to a CSV file for `domain_expert_critiques`. (`[notebooks/03-llm-as-a-judge.ipynbL170-R171](diffhunk://#diff-4e0dc95ba773844500d992e2df38b2fb14d662ce21793a0a5ec3cac104a38a3dL170-R171)`)

Code enhancements:
* Added code to set the `OPENAI_API_KEY` environment variable. (`[notebooks/03-llm-as-a-judge.ipynbR235-R246](diffhunk://#diff-4e0dc95ba773844500d992e2df38b2fb14d662ce21793a0a5ec3cac104a38a3dR235-R246)`)

Markdown updates:
* Updated markdown cells to improve explanations and added new sections for better structure. (`[[1]](diffhunk://#diff-4e0dc95ba773844500d992e2df38b2fb14d662ce21793a0a5ec3cac104a38a3dL269-R297)`, `[[2]](diffhunk://#diff-4e0dc95ba773844500d992e2df38b2fb14d662ce21793a0a5ec3cac104a38a3dL292-R334)`)
* Changed the notebook metadata to reflect the Python version update from 3.12.3 to 3.11.9. (`[notebooks/03-llm-as-a-judge.ipynbL318-R353](diffhunk://#diff-4e0dc95ba773844500d992e2df38b2fb14d662ce21793a0a5ec3cac104a38a3dL318-R353)`)