### PR TITLE
docs: add exercise to nb 05

### DIFF
--- a/notebooks/03-llm-as-a-judge.ipynb
+++ b/notebooks/03-llm-as-a-judge.ipynb
@@ -308,9 +308,11 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "22",
    "metadata": {},
+   "outputs": [],
    "source": [
     "full_judges"
    ]

--- a/notebooks/05-improve-metadata-search.ipynb
+++ b/notebooks/05-improve-metadata-search.ipynb
@@ -5,36 +5,27 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Improve Metadata Search"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# TODO: add more descriptions"
+    "# Leverage Metadata to Improve Search"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "1",
    "metadata": {},
    "source": [
-    "Our RAG is not very good on answering questions regarding movies metadata such as release year or gnre o. \n",
-    "For example, how our system deal with questions like: \n",
-    "- Could you suggest a romantic movies from '90s\n",
-    "- I love action movies could you suggest one? \n",
+    "Until now, our RAG has only leveraged similarity between user questions and movie plots, with or without HyDE. **Our dataset is richer than just the plot column.** What about the release date or genre columns? Could this information help us improve our movie expertise? \n",
     "\n",
-    "Right now, with just the simple semantic search between query and movies plots we don't leverage the metadata stored in our database."
+    "It turns out that our RAG could better reply to some questions. How our system deals with questions like: \n",
+    "- Could you suggest a romantic movie from the '90s\n",
+    "- I love action movies, could you suggest one? \n",
+    "\n",
+    "Let's see what we can do to improve our \"movies buddy\" a step further."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +49,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Let's Play with LanceDB"
@@ -67,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +99,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "8",
    "metadata": {},
    "source": [
     "Let's see what movies are retrieved from database just using semantic search."
@@ -117,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +129,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "11",
    "metadata": {},
    "source": [
     "The retrieved movies looks good, they are all aventure or fantasy movies with some relation with dragosn as asked by the user. **The problem is that many of them are not from 90s!** This is due the fact that the semantic search using enbeddings doesn't taken into account the movies release year.\n",
@@ -149,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,7 +151,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "13",
    "metadata": {},
    "source": [
     "Hurray! Looks better, all movies now are from 90s. Now the metadata informations in the questions are useless we could just search for \"dragons\" and see what happen!"
@@ -169,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +171,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "15",
    "metadata": {},
    "source": [
     "Even better! So, based on this experiments we need something to convert the natural language user query to a SQL-like filter (or other languages supported by your vector database). \n",
@@ -189,9 +180,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "## 🏋🏻 Exercise: Play With LanceDB Filters!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "Before exploring how we can generate filters and questions given a natural language question using LLM, **it is crucial to understand how search works**. \n",
+    "\n",
+    "Take some time to play with lanceDB filters, dig into [documentation](https://lancedb.github.io/lancedb/sql/), and try to find some edge cases or database limitations. "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,7 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,7 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,7 +357,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "Now that we have improve the `get_records` methods taking into consideration also metadata. We could build the rag again! "
@@ -357,7 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,7 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,7 +464,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "# Results"
@@ -464,7 +473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,7 +486,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +499,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -503,7 +512,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "# But... Is Our RAG Improved?"
@@ -511,23 +520,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "Let's take our questions/answers dataset and run again our LLM-as-a-Judge"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "32",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "questions_answers_df = pl.read_excel(\n",
-    "    source=\"../data/eval_questions_with_critiques.xlsx\",\n",
-    "    sheet_name=\"Sheet1\",\n",
-    ").select([\"question\", \"rag_answer\"])"
    ]
   },
   {
@@ -537,7 +533,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "replied_answers = answer_multiple_questions(questions_answers_df, ask)"
+    "questions_answers_df = pl.read_csv(\n",
+    "    source=\"eval_replies.csv\"\n",
+    ").select([\"question\", \"rag_answer\"])"
    ]
   },
   {
@@ -547,7 +545,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "judged_questions_answer_df = llm_as_a_judge(questions_answers_df, client)"
+    "replied_answers = answer_multiple_questions(questions_answers_df, ask)"
    ]
   },
   {
@@ -557,7 +555,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "judged_questions_answer_df = llm_as_a_judge(questions_answers_df, client)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "judged_questions_answer_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37",
+   "metadata": {},
+   "source": [
+    "## 🏋🏻 Exercise: Improve Query Generator Prompt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38",
+   "metadata": {},
+   "source": [
+    "The system could not be replying perfectly yet. Have a look again on query generation system message, iterate over it adding some rules or examples and try to fix many bugs as possible. "
    ]
   }
  ],


### PR DESCRIPTION
This pull request includes significant updates to two Jupyter notebooks, `03-llm-as-a-judge.ipynb` and `05-improve-metadata-search.ipynb`, with the main focus on improving metadata search and enhancing the user experience.

Key changes include:

### Notebook `03-llm-as-a-judge.ipynb`:
* Changed a cell type from "raw" to "code" and initialized it with null execution count and empty outputs. (`notebooks/03-llm-as-a-judge.ipynb`)

### Notebook `05-improve-metadata-search.ipynb`:
* Enhanced the introduction and explanations, emphasizing the potential of leveraging metadata to improve search results. (`notebooks/05-improve-metadata-search.ipynb`)
* Updated cell ids throughout the notebook to maintain consistency after adding or removing cells. (`notebooks/05-improve-metadata-search.ipynb`) [[1]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L50-R41) [[2]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L61-R52) [[3]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L70-R61) [[4]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L88-R79) [[5]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L99-R90) [[6]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L111-R102) [[7]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L120-R111) [[8]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L130-R121) [[9]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L141-R132) [[10]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L152-R143) [[11]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L163-R154) [[12]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L172-R163) [[13]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L183-R203) [[14]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L260-R269) [[15]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L270-R279) [[16]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L282-R291) [[17]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L307-R316) [[18]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L351-R360) [[19]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L360-R369) [[20]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L376-R385) [[21]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L415-R424) [[22]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L458-R467) [[23]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L467-R476) [[24]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L480-R489) [[25]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L493-R502) [[26]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L506-R523) [[27]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L523-R544) [[28]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L546-R554) [[29]](diffhunk://#diff-55ac1ac736d431ed6b894c949aa2da344ec92f9a25220163742c95c3be454fb2L556-R585)
* Added new markdown cells for exercises to encourage users to explore LanceDB filters and improve the query generation prompt. (`notebooks/05-improve-metadata-search.ipynb`) (F550ae4dL171R180, F550ae4dL561R570)
* Replaced Excel file reading with CSV file reading for the questions/answers dataset. (`notebooks/05-improve-metadata-search.ipynb`) (F550ae4dL529R520)